### PR TITLE
Falsch benannte Regeln und nicht funktionierende Regeln in config.json, Config.hs & Rules.hs beheben.

### DIFF
--- a/config.json
+++ b/config.json
@@ -77,6 +77,9 @@
         "rule": "RedundantModifiers"
     },
     {
+        "rule": "SameExecutionsInIf"
+    },
+    {
         "rule": "UseAssignOp"
     },
     {

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -31,6 +31,7 @@ data Rule
   | ProhibitMyIdentPrefix
   | ReduceScope
   | RedundantModifiers
+  | SameExecutionsInIf
   | UseAssignOp
   | UseElse
   | UseIncrementDecrementOperator
@@ -64,6 +65,7 @@ instance FromJSON Rule where
       "ProhibitMyIdentPrefix" -> pure ProhibitMyIdentPrefix
       "ReduceScope" -> pure ReduceScope
       "RedundantModifiers" -> pure RedundantModifiers
+      "SameExecutionsInIf" -> pure SameExecutionsInIf
       "UseAssignOp" -> pure UseAssignOp
       "UseElse" -> pure UseElse
       "UseIncrementDecrementOperator" -> pure UseIncrementDecrementOperator

--- a/src/Language/Java/Rules.hs
+++ b/src/Language/Java/Rules.hs
@@ -24,6 +24,7 @@ import qualified Language.Java.Rules.ProhibitAnnotations as ProhibitAnnotations
 import qualified Language.Java.Rules.ProhibitMyIdentPrefix as ProhibitMyIdentPrefix
 import qualified Language.Java.Rules.ReduceScope as ReduceScope
 import qualified Language.Java.Rules.RedundantModifiers as RedundantModifiers
+import qualified Language.Java.Rules.SameExecutionsInIf as SameExecutionsInIf
 import qualified Language.Java.Rules.UseAssignOp as UseAssignOp
 import Language.Java.Rules.UseElse as UseElse (check)
 import qualified Language.Java.Rules.UseIncrementDecrementOperator as UseIncrementDecrementOperator
@@ -95,6 +96,7 @@ checkFromConfig (ProhibitAnnotations whitelist) = ProhibitAnnotations.check whit
 checkFromConfig ProhibitMyIdentPrefix = ProhibitMyIdentPrefix.check
 checkFromConfig ReduceScope = ReduceScope.check
 checkFromConfig RedundantModifiers = RedundantModifiers.check
+checkFromConfig SameExecutionsInIf = SameExecutionsInIf.check
 checkFromConfig UseAssignOp = UseAssignOp.check
 checkFromConfig UseElse = UseElse.check
 checkFromConfig UseIncrementDecrementOperator = UseIncrementDecrementOperator.check


### PR DESCRIPTION
closes #354 